### PR TITLE
Adds an ENV to the Dockerfile for PROJECT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:stretch-slim
 
+ARG project
+
 # Update apt database and install necessary packages.
 RUN apt-get update -qq && apt-get install -qq \
     apt-transport-https \
@@ -28,6 +30,6 @@ EXPOSE 9116
 
 # Mount the GCS bucket that contains the snmp_exporter config and then start
 # snmp_exporter.
-CMD gcsfuse -o ro switch-config-mlab-sandbox /etc/snmp_exporter && \
+CMD gcsfuse -o ro switch-config-${project} /etc/snmp_exporter && \
     /root/go/bin/snmp_exporter \
     --config.file=/etc/snmp_exporter/snmp_exporter_config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch-slim
 
-ENV PROJECT
+ENV PROJECT mlab-sandbox
 
 # Update apt database and install necessary packages.
 RUN apt-get update -qq && apt-get install -qq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch-slim
 
-ARG project
+ENV PROJECT
 
 # Update apt database and install necessary packages.
 RUN apt-get update -qq && apt-get install -qq \
@@ -30,6 +30,6 @@ EXPOSE 9116
 
 # Mount the GCS bucket that contains the snmp_exporter config and then start
 # snmp_exporter.
-CMD gcsfuse -o ro switch-config-${project} /etc/snmp_exporter && \
+CMD gcsfuse -o ro switch-config-${PROJECT} /etc/snmp_exporter && \
     /root/go/bin/snmp_exporter \
     --config.file=/etc/snmp_exporter/snmp_exporter_config.yaml

--- a/deploy_snmp_exporter.sh
+++ b/deploy_snmp_exporter.sh
@@ -59,7 +59,7 @@ gcloud compute instances create $GCE_NAME --address $GCE_IP_NAME \
 gcloud compute scp $SCP_FILES $GCE_NAME:~
 
 # Build the snmp_exporter Docker container.
-gcloud compute ssh $GCE_NAME --command "docker build --tag ${IMAGE_TAG} ."
+gcloud compute ssh $GCE_NAME --command "docker build --build-arg project=${PROJECT} --tag ${IMAGE_TAG} ."
 
 # Start a new container based on the new/updated image.  The SYS_ADMIN
 # capability is needed here, along with access to /dev/fuse, because the

--- a/deploy_snmp_exporter.sh
+++ b/deploy_snmp_exporter.sh
@@ -59,7 +59,7 @@ gcloud compute instances create $GCE_NAME --address $GCE_IP_NAME \
 gcloud compute scp $SCP_FILES $GCE_NAME:~
 
 # Build the snmp_exporter Docker container.
-gcloud compute ssh $GCE_NAME --command "docker build --build-arg project=${PROJECT} --tag ${IMAGE_TAG} ."
+gcloud compute ssh $GCE_NAME --command "docker build --tag ${IMAGE_TAG} ."
 
 # Start a new container based on the new/updated image.  The SYS_ADMIN
 # capability is needed here, along with access to /dev/fuse, because the
@@ -67,7 +67,7 @@ gcloud compute ssh $GCE_NAME --command "docker build --build-arg project=${PROJE
 # file. There is a possibility that a finer-grained capability exists that will
 # allow a container to mount a filesystem, but SYS_ADMIN is the one that I found
 # people recommending.
-gcloud compute ssh $GCE_NAME --command "docker run --detach --publish 9116:9116 --cap-add SYS_ADMIN --device /dev/fuse ${IMAGE_TAG}"
+gcloud compute ssh $GCE_NAME --command "docker run --detach --publish 9116:9116 --cap-add SYS_ADMIN --device /dev/fuse --env PROJECT=${PROJECT} ${IMAGE_TAG}"
 
 # Run Prometheus node_exporter in a container so we can gather VM metrics.
 gcloud compute ssh $GCE_NAME --command "docker run --detach --publish 9100:9100 --volume /proc:/host/proc --volume /sys:/host/sys prom/node-exporter --path.procfs /host/proc --path.sysfs /host/sys --no-collector.arp --no-collector.bcache --no-collector.conntrack --no-collector.edac --no-collector.entropy --no-collector.filefd --no-collector.hwmon --no-collector.infiniband --no-collector.ipvs --no-collector.mdadm --no-collector.netstat --no-collector.sockstat --no-collector.time --no-collector.timex --no-collector.uname --no-collector.vmstat --no-collector.wifi --no-collector.xfs --no-collector.zfs"


### PR DESCRIPTION
Currently, and mistakenly, the Dockerfile is configured to always attempt to mount the a GCS bucket from mlab-sandbox. This PR adds a new ENV named `PROJECT` to the Dockerfile. And we manipulate the value of this variable by passing `--env PROJECT=${PROJECT}` in the deploy script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-snmp-exporter/10)
<!-- Reviewable:end -->
