### PR TITLE
Docker containers should only listen on internal VPC IP address

### DIFF
--- a/deploy_snmp_exporter.sh
+++ b/deploy_snmp_exporter.sh
@@ -76,7 +76,7 @@ gcloud compute ssh $GCE_NAME --command "docker build --tag ${IMAGE_TAG} ."
 # file. There is a possibility that a finer-grained capability exists that will
 # allow a container to mount a filesystem, but SYS_ADMIN is the one that I found
 # people recommending.
-gcloud compute ssh $GCE_NAME --command "docker run --detach --publish ${INTERNAL_IP}:9116:9116 --name ${GCE_NAME} --cap-add SYS_ADMIN --device /dev/fuse --env PROJECT=${PROJECT} ${IMAGE_TAG}"
+gcloud compute ssh $GCE_NAME --command "docker run --detach --publish ${INTERNAL_IP}:9116:9116 --name ${GCE_NAME} --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --env PROJECT=${PROJECT} ${IMAGE_TAG}"
 
 # Run Prometheus node_exporter in a container so we can gather VM metrics.
 gcloud compute ssh $GCE_NAME --command "docker run --detach --publish ${INTERNAL_IP}:9100:9100 --name node-exporter --volume /proc:/host/proc --volume /sys:/host/sys prom/node-exporter --path.procfs /host/proc --path.sysfs /host/sys --no-collector.arp --no-collector.bcache --no-collector.conntrack --no-collector.edac --no-collector.entropy --no-collector.filefd --no-collector.hwmon --no-collector.infiniband --no-collector.ipvs --no-collector.mdadm --no-collector.netstat --no-collector.sockstat --no-collector.time --no-collector.timex --no-collector.uname --no-collector.vmstat --no-collector.wifi --no-collector.xfs --no-collector.zfs"


### PR DESCRIPTION
Currently, Docker containers listen on all interfaces. This means that the snmp-exporter is publicly accessible. It's not a privacy issue, but just one of potential abuse of the service. This PR causes the VM deploy script to determine the internal VPC IP address of the newly created VM, and then launches the Docker containers only listening on this internal, private IP address.

Also of note in this PR is the addition of `--security-opt apparmor:unconfined` to docker-run. This wasn't necessary before, so I assume that it is because of changes in the underlying OS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-snmp-exporter/11)
<!-- Reviewable:end -->
