### PR TITLE
Updates references to newly renamed repo snmp-exporter-support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ deploy:
     script: "$TRAVIS_BUILD_DIR/deploy_snmp_exporter.sh mlab-sandbox SERVICE_ACCOUNT_mlab_sandbox"
     skip_cleanup: true
     on:
-      repo: m-lab/prometheus-snmp-exporter
+      repo: m-lab/snmp-exporter-support
       branch: sandbox-*
       condition: "$TRAVIS_EVENT_TYPE == push"
   # Staging - conditionally deploy to GCP project mlab-staging
@@ -17,7 +17,7 @@ deploy:
     script: "$TRAVIS_BUILD_DIR/deploy_snmp_exporter.sh mlab-staging SERVICE_ACCOUNT_mlab_staging"
     skip_cleanup: true
     on:
-      repo: m-lab/prometheus-snmp-exporter
+      repo: m-lab/snmp-exporter-support
       branch: master
       condition: "$TRAVIS_EVENT_TYPE == push"
   # Production - conditionally deploy to GCP project mlab-oti
@@ -25,5 +25,5 @@ deploy:
     script: "$TRAVIS_BUILD_DIR/deploy_snmp_exporter.sh mlab-oti SERVICE_ACCOUNT_mlab_oti"
     skip_cleanup: true
     on:
-      repo: m-lab/prometheus-snmp-exporter
+      repo: m-lab/snmp-exporter-support
       tags: true

--- a/deploy_snmp_exporter.sh
+++ b/deploy_snmp_exporter.sh
@@ -10,7 +10,7 @@ PROJECT=${1:?Please provide project name: $USAGE}
 KEYNAME=${2:?Please provide an authentication key name: $USAGE}
 
 SCP_FILES="Dockerfile"
-IMAGE_TAG="m-lab/prometheus-snmp-exporter"
+IMAGE_TAG="m-lab/snmp-exporter-support"
 GCE_ZONE="us-central1-a"
 GCE_NAME="snmp-exporter"
 GCE_IP_NAME="snmp-exporter-public-ip"


### PR DESCRIPTION
The repo was just renamed:

prometheus-snmp-exporter -> snmp-exporter-support

For this to be cleanly done a few changes has to be made.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/snmp-exporter-support/12)
<!-- Reviewable:end -->
